### PR TITLE
fix: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,17 @@ docker run --rm -it -e SEED=123 ghcr.io/all-cups/it_one_cup_sql
 docker run --rm -it ghcr.io/all-cups/it_one_cup_sql --help
 ```
 
-## Пример локального запуска 
+## Пример локального запуска
 
 Для двух решений с сохранением содержимого init.sql и передачей своего файла настроек мира.
 
 ### MacOS / Linux:
 ```shell
 docker run \
-  --mount "type=bind,src=$(pwd)/my-solution.sql,dst=/tmp/player1-solution.sql" \
-  --mount "type=bind,src=$(pwd)/quick_start.sql,dst=/tmp/player2-solution.sql" \
-  --mount "type=bind,src=$(pwd)/init.sql,dst=/tmp/init.sql" \
-  --mount "type=bind,src=$(pwd)/my-options.toml,dst=/tmp/options.toml" \
+  --volume $(pwd):/tmp \
   --rm -it -e SEED=123456 ghcr.io/all-cups/it_one_cup_sql \
-  --solution /tmp/player1-solution.sql \
-  --solution /tmp/player2-solution.sql \
+  --solution /tmp/quick_start.sql \
+  --solution /tmp/quick_start_with_trade.sql \
   --dump-init /tmp/init.sql \
   --options /tmp/options.toml \
   --log INFO   


### PR DESCRIPTION
Предлагаю скорректировать инструкцию по запуску в докере.
**Преимущества:**
1. Сразу вся текущая директория монитруется в `/tmp`;
2. Используются существующие демо-стратегии;
3. Участник клонирует репозиторий, запускает предлагаемую команду и получает рабочий local-runner.
